### PR TITLE
Update graph.js

### DIFF
--- a/src/server/views/js/graph.js
+++ b/src/server/views/js/graph.js
@@ -14,7 +14,7 @@ function showGraph(element, infos, value) {
 			ylabel: infos[2],
 			xlabel: infos[0],
 			legend: 'always',
-			rollPeriod: 30,
+			//rollPeriod: 30,
 			showRangeSelector: true,
 			resizable: "both",
 			connectSeparatedPoints: false


### PR DESCRIPTION
Disable rollPeriod setting for Dygraphs : 
Currently, rollPeriod smooths the data over 30 time steps by averaging. The number of data points displayed does not change. This argument is only used to make the graph "easier to read". But, this smoothing tends to hide certain data (such as outliers) and can introduce a time lag.